### PR TITLE
Add deploy-to-tsuru script, README tweaks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+.PHONY: deploy-to-tsuru
+
 clean:
 	@find . -name "*.pyc" -delete
 
@@ -11,3 +13,6 @@ test: clean deps
 
 run: clean deps
 	@DEBUG=true ./manage.py runserver
+
+deploy-to-tsuru:
+	./deploy-to-tsuru

--- a/README.md
+++ b/README.md
@@ -1,16 +1,23 @@
-#tsuru-dashboard
+# tsuru-dashboard
 
 [![Build Status](https://secure.travis-ci.org/tsuru/tsuru-dashboard.png?branch=master)](http://travis-ci.org/tsuru/tsuru-dashboard)
 [![Build Status](https://drone.io/github.com/tsuru/tsuru-dashboard/status.png)](https://drone.io/github.com/tsuru/tsuru-dashboard/latest)
 
-tsuru-dashboard is a django-base project aimed to providing a tsuru dashboard.
-
+tsuru-dashboard is a Django-based project aimed at providing a Web-based dashboard for tsuru.
 
 For issue tracking:
 
-    * https://github.com/tsuru/tsuru-dashboard/issues
+* https://github.com/tsuru/tsuru-dashboard/issues
 
-#Getting Started
+# Deploying to tsuru
+
+tsuru-dashboard can be deployed to tsuru like any other app.
+
+Try:
+
+    ./deploy-to-tsuru
+
+# Setting up a development environment
 
 For local development, first create a virtualenv and install the deps:
 
@@ -21,6 +28,6 @@ If all is well you should able to run the local server:
     $ export TSURU_HOST=http://tsuru-api-endpoint.com
     $ ./manage.py runserver
 
-#Running tests
+# Running tests
 
     $ make test

--- a/deploy-to-tsuru
+++ b/deploy-to-tsuru
@@ -1,0 +1,50 @@
+#!/bin/sh
+
+set -o errexit
+set -o errtrace
+set -o nounset
+
+GIT_URL="git@github.com:tsuru/tsuru-dashboard"
+TSURU_APP=$(basename ${GIT_URL})
+PLATFORM="python"
+TEAM_OWNER="admin"
+TSURU="tsuru"
+
+if [ -f tsuru.yaml -o -f tsuru.yml ]; then
+    echo "********************************************************************"
+    echo "  We seem to be in a tsuru app directory; skipping git clone..."
+    echo "********************************************************************"
+    echo
+else
+    echo "********************************************************************"
+    echo "  git cloning ${GIT_URL} ..."
+    echo "********************************************************************"
+    git clone ${GIT_URL} ${TSURU_APP}
+    cd ${TSURU_APP}
+    echo
+fi
+
+echo "********************************************************************"
+echo "  Creating a tsuru app..."
+echo "********************************************************************"
+${TSURU} app-create ${TSURU_APP} ${PLATFORM} --team ${TEAM_OWNER}
+echo
+
+echo "********************************************************************"
+echo "  Setting up git remote for tsuru..."
+echo "********************************************************************"
+git_remote_url=$(${TSURU} app-info -a ${TSURU_APP} | awk '/^Repository:/ { print $2 }')
+git remote add tsuru $git_remote_url || true
+git remote -v | grep '^tsuru'
+echo
+
+echo "********************************************************************"
+echo "  Pushing app to tsuru..."
+echo "********************************************************************"
+${TSURU} app-deploy .
+echo
+
+echo "********************************************************************"
+echo "  Showing app info..."
+echo "********************************************************************"
+${TSURU} app-info


### PR DESCRIPTION
This adds a shell script called `deploy-to-tsuru`, that uh, deploys to tsuru.

And then I reference it in `README.md` and made a few other tweaks.

Here's what the output of `deploy-to-tsuru` looks like: https://gist.github.com/msabramo/164f1bdbbd3c56d59df6
