### PR TITLE
Move to cdnjs for Morris.js dependencies

### DIFF
--- a/apps/templates/apps/metrics.html
+++ b/apps/templates/apps/metrics.html
@@ -3,7 +3,7 @@
 {% block extra_css %}
 <link rel="stylesheet" href="{{ STATIC_URL }}css/abyss.widget.css" />
 <link rel="stylesheet" href="{{ STATIC_URL }}css/detail.css" />
-<link rel="stylesheet" href="http://cdn.oesmith.co.uk/morris-0.5.1.css">
+<link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/morris.js/0.5.1/morris.css">
 {% endblock %}
 
 {% block app-content %}
@@ -26,7 +26,7 @@
 <script src="{{ STATIC_URL }}js/apps/graph.js"></script>
 <script src="{{ STATIC_URL }}js/confirmation.js"></script>
 <script src="//cdnjs.cloudflare.com/ajax/libs/raphael/2.1.0/raphael-min.js"></script>
-<script src="http://cdn.oesmith.co.uk/morris-0.5.1.min.js"></script>
+<script src="//cdnjs.cloudflare.com/ajax/libs/morris.js/0.5.1/morris.min.js"></script>
 <script src="{{ STATIC_URL }}js/apps/detail.js"></script>
 <script type="text/javascript">
 var appName = "{{ app.name }}";


### PR DESCRIPTION
Altered where the dashboard loads the JS / CSS for morris.js to cdnjs, so that you can
view the metrics dashboard over SSL without getting mixed content issues.