### PR TITLE
Fix to remove two references to old CDN

### DIFF
--- a/apps/templates/apps/metric_details.html
+++ b/apps/templates/apps/metric_details.html
@@ -67,7 +67,7 @@
 <script src="{{ STATIC_URL }}js/apps/graphite.js"></script>
 <script src="{{ STATIC_URL }}js/apps/elasticsearch.js"></script>
 <script src="//cdnjs.cloudflare.com/ajax/libs/raphael/2.1.0/raphael-min.js"></script>
-<script src="//cdn.oesmith.co.uk/morris-0.5.1.min.js"></script>
+<script src="//cdnjs.cloudflare.com/ajax/libs/morris.js/0.5.1/morris.min.js"></script>
 <script src="{{ STATIC_URL }}js/apps/metrics.js"></script>
 <script type="text/javascript">
 	var appName = "{{ app.name }}";

--- a/apps/templates/apps/settings.html
+++ b/apps/templates/apps/settings.html
@@ -112,7 +112,7 @@ table td, table th {
 <script src="{{ STATIC_URL }}js/apps/graph.js"></script>
 <script src="{{ STATIC_URL }}js/confirmation.js"></script>
 <script src="//cdnjs.cloudflare.com/ajax/libs/raphael/2.1.0/raphael-min.js"></script>
-<script src="//cdn.oesmith.co.uk/morris-0.5.1.min.js"></script>
+<script src="//cdnjs.cloudflare.com/ajax/libs/morris.js/0.5.1/morris.min.js"></script>
 <script src="{{ STATIC_URL }}js/apps/detail.js"></script>
 <script type="text/javascript">
 var appName = "{{ app.name }}";


### PR DESCRIPTION
In https://github.com/tsuru/tsuru-dashboard/pull/92 I missed two references to
non cdnjs files. This pull request fixes those to ensure that the dashboard can
run happily under SSL as the morris CDN does not respond to SSL connections.