### PR TITLE
Fix graphite series name

### DIFF
--- a/abyss/static_files/js/apps/graphite.js
+++ b/abyss/static_files/js/apps/graphite.js
@@ -90,7 +90,7 @@
 	}
 
 	var graphitePrefix = function(opts) {
-		var graphitePrefix = opts["envs"]["GRAPHITE_PREFIX"] || "statsite";
+		var graphitePrefix = opts["envs"]["GRAPHITE_PREFIX"] || "stats.gauges";
 		return graphitePrefix + ".tsuru." + opts["appName"];
 	}
 


### PR DESCRIPTION
Update `statside` to `stats.gauges` so that it matches collected metrics. This way data is correctly retrieved from graphite and displayed on graphs in dashboard.