### PR TITLE
Stop toggle env variables list

### DIFF
--- a/apps/templates/apps/settings.html
+++ b/apps/templates/apps/settings.html
@@ -40,9 +40,9 @@
 	</div>
 	<div class="row-fluid">
 		<div class="span10">
-            <div class="content settings-toggle">
+            <div class="content">
             <h3>Environment variables</h3>
-            <p><a href=#>&#x25BC;</a> {{ app.envs|length }} enviroment variables</p>
+            <p class="settings-toggle"><a href=#>&#x25BC;</a> {{ app.envs|length }} enviroment variables</p>
             <table class="table hide">
                 <thead>
                 <tr>


### PR DESCRIPTION
We can't copy and paste env variables because the entire div.container hide and display table!