### PR TITLE
Fix tsuru container label names

### DIFF
--- a/tsuru_dashboard/metrics/backends/prometheus/__init__.py
+++ b/tsuru_dashboard/metrics/backends/prometheus/__init__.py
@@ -131,9 +131,9 @@ class Prometheus(object):
 
 class AppBackend(Prometheus):
     def __init__(self, app, url, process_name=None, date_range=None):
-        query = 'container_label_tsuru_app_name="%s"' % app["name"]
+        query = 'container_label_app_name="%s"' % app["name"]
         if process_name is not None:
-            query += ',container_label_tsuru_process_name="%s"' % process_name
+            query += ',container_label_app_process="%s"' % process_name
         return super(AppBackend, self).__init__(
             url=url,
             query=query,


### PR DESCRIPTION
Some point in time tsuru changed the labels `tsuru-app-name` to just `app-name` and `tsuru-process-name` to just `app-process`. This change fixes this issue, which prevents tsuru-dashboard from reading correctly the metrics from a Prometheus host.