### PR TITLE
Fix container IP in node list

### DIFF
--- a/tsuru_dashboard/admin/models.py
+++ b/tsuru_dashboard/admin/models.py
@@ -11,25 +11,25 @@ def extract_ip(address):
 
 
 class Node():
-    def __init__(self, data, units_responses=None):
+    def __init__(self, data, units_response=None):
         self.data = data or {}
+        self.load_units(units_response)
+
+    def load_units(self, response):
         self.units = []
-        if not units_responses:
+        if not response or response.status_code != 200:
             return
-        for response in units_responses:
-            if not response or response.status_code != 200:
-                continue
 
-            node_units = response.json()
-            if not node_units:
-                continue
+        node_units = response.json()
+        if not node_units:
+            return
 
-            addr = node_units[0].get('IP') or node_units[0].get('Ip')
-            if not addr:
-                continue
+        addr = node_units[0].get('IP') or node_units[0].get('Ip')
+        if not addr:
+            return
 
-            if extract_ip(addr) == extract_ip(self.address()):
-                self.units = node_units
+        if extract_ip(addr) == extract_ip(self.address()):
+            self.units = node_units
 
     def address(self):
         return self.data.get('Address')

--- a/tsuru_dashboard/admin/models.py
+++ b/tsuru_dashboard/admin/models.py
@@ -24,7 +24,7 @@ class Node():
             if not node_units:
                 continue
 
-            addr = node_units[0].get('IP')
+            addr = node_units[0].get('IP') or node_units[0].get('Ip')
             if not addr:
                 continue
 

--- a/tsuru_dashboard/admin/models.py
+++ b/tsuru_dashboard/admin/models.py
@@ -17,17 +17,14 @@ class Node():
         if not units_responses:
             return
         for response in units_responses:
-            if not response:
-                continue
-
-            if response.status_code != 200:
+            if not response or response.status_code != 200:
                 continue
 
             node_units = response.json()
             if not node_units:
                 continue
 
-            addr = node_units[0].get('HostAddr') or node_units[0].get('hostaddr')
+            addr = node_units[0].get('IP')
             if not addr:
                 continue
 

--- a/tsuru_dashboard/admin/tests/test_node_info_view.py
+++ b/tsuru_dashboard/admin/tests/test_node_info_view.py
@@ -4,7 +4,7 @@ from django.test import TestCase
 from django.test.client import RequestFactory
 
 
-class ListAppJsonViewTest(TestCase):
+class NodeInfoViewTest(TestCase):
     @patch("tsuru_dashboard.auth.views.token_is_valid")
     def test_should_use_node_info_template(self, token_is_valid):
         token_is_valid.return_value = True

--- a/tsuru_dashboard/admin/tests/test_pool_info_view.py
+++ b/tsuru_dashboard/admin/tests/test_pool_info_view.py
@@ -65,7 +65,7 @@ class PoolInfoViewTest(TestCase):
         for addr in ["http://128.0.0.1:4243", "http://myserver.com:2375", "http://127.0.0.1:2375", "http://myserver2.com:2375"]:
             url = "{}/docker/node/{}/containers".format(settings.TSURU_HOST, addr)
             body = json.dumps(
-                [{"Status": "started", "HostAddr": addr}, {"Status": "stopped", "HostAddr": addr}])
+                [{"Status": "started", "HostAddr": addr, "IP": addr}, {"Status": "stopped", "HostAddr": addr, "IP": addr}])
             httpretty.register_uri(httpretty.GET, url, body=body, status=200)
 
         response = PoolInfo.as_view()(self.request, pool="mypool")
@@ -76,23 +76,23 @@ class PoolInfoViewTest(TestCase):
              "metadata": {"LastSuccess": "2014-08-01T14:09:40-03:00", "pool": "mypool"},
              "pool": "mypool",
              "last_success": date,
-             "units": [{"HostAddr": "http://128.0.0.1:4243", "Status": "started"},
-                       {"HostAddr": "http://128.0.0.1:4243", "Status": "stopped"}],
+             "units": [{"HostAddr": "http://128.0.0.1:4243", "IP": "http://128.0.0.1:4243", "Status": "started"},
+                       {"HostAddr": "http://128.0.0.1:4243", "IP": "http://128.0.0.1:4243", "Status": "stopped"}],
              "status": "ready"},
             {"address": "http://127.0.0.1:2375",
              "units_stats": {"started": 1, "stopped": 1, "total": 2},
              "metadata": {"LastSuccess": "2014-08-01T14:09:40-03:00", "pool": "mypool"},
              "pool": "mypool",
-             "units": [{"HostAddr": "http://127.0.0.1:2375", "Status": "started"},
-                       {"HostAddr": "http://127.0.0.1:2375", "Status": "stopped"}],
+             "units": [{"HostAddr": "http://127.0.0.1:2375", "IP": "http://127.0.0.1:2375", "Status": "started"},
+                       {"HostAddr": "http://127.0.0.1:2375", "IP": "http://127.0.0.1:2375", "Status": "stopped"}],
              "last_success": date,
              "status": "ready"},
             {"address": "http://myserver2.com:2375",
              "units_stats": {"started": 1, "stopped": 1, "total": 2},
              "metadata": {"LastSuccess": "2014-08-01T14:09:40-03:00"},
              "pool": "mypool",
-             "units": [{"HostAddr": "http://myserver2.com:2375", "Status": "started"},
-                       {"HostAddr": "http://myserver2.com:2375", "Status": "stopped"}],
+             "units": [{"HostAddr": "http://myserver2.com:2375", "IP": "http://myserver2.com:2375", "Status": "started"},
+                       {"HostAddr": "http://myserver2.com:2375", "IP": "http://myserver2.com:2375", "Status": "stopped"}],
              "last_success": date,
              "status": "ready"},
         ]}


### PR DESCRIPTION
Non-web processes don't expose `HostAddr`. This PR changes the node filtering to use `IP` field. I've also made a refactoring in `Node` class to make it easier to understand.