### PR TITLE
Improve event error visualization by rendering as a text block

### DIFF
--- a/tsuru_dashboard/templates/events/info/_content.html
+++ b/tsuru_dashboard/templates/events/info/_content.html
@@ -7,7 +7,8 @@
     <div class="col-md-12">
       <div class="content event-info">
         <label>Status:</label>
-        <span class="{% if not event.Running and not event.CancelInfo.Canceled and not event.Error %}status-success{% endif %}{% if event.Running %}status-running{% endif %}{% if event.Error %}status-error{% endif %}">
+        <span
+          class="{% if not event.Running and not event.CancelInfo.Canceled and not event.Error %}status-success{% endif %}{% if event.Running %}status-running{% endif %}{% if event.Error %}status-error{% endif %}">
           {% if event.Running %}
           Running
           {% endif %}
@@ -19,7 +20,10 @@
           {% endif %}
         </span>
         {% if event.Error %}
-        <label>Error message:</label><span>{{ event.Error }}</span>
+        <label class="break">Error message:</label>
+        <div>
+          <pre>{{ event.Error | escape }}</pre>
+        </div>
         {% endif %}
         {% if event.CancelInfo.Canceled %}
         <label>Event canceled by:</label><span>{{ event.CancelInfo.Owner }}</span>
@@ -31,7 +35,7 @@
         <label>Targets:</label>
         <span>{{ event.Target.Type }}({{ event.Target.Value }})</span>
         {% for et in event.ExtraTargets %}
-          <span>{{ et.Target.Type }}({{ et.Target.Value }})</span>
+        <span>{{ et.Target.Type }}({{ et.Target.Value }})</span>
         {% endfor %}
         {% if event.StartTime %}
         <label>Started at:</label><span>{{ event.StartTime|string_to_date|date:" d-m-Y H:i:s " }}</span>
@@ -53,7 +57,9 @@
         {% endif %}
         {% if event.Log %}
         <label class="break">Log:</label>
-        <div><pre>{{ event.Log | escape }}</pre></div>
+        <div>
+          <pre>{{ event.Log | escape }}</pre>
+        </div>
         {% endif %}
       </div>
     </div>


### PR DESCRIPTION
Quoting the error string was weird for long error messages present in deploy operation which usually include newlines.